### PR TITLE
New base rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
   extends: ['eslint:recommended', 'standard', 'plugin:prettier/recommended'],
 
   rules: {
-    'no-console': 'warn',
+    'no-console': 'error',
     eqeqeq: ['warn', 'always', { null: 'ignore' }],
 
     'promise/no-return-wrap': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,10 +36,19 @@ module.exports = {
     'import/no-unresolved': ['error', { ignore: ['svg-inline-loader'] }],
     'import/named': 'error',
     'import/default': 'error',
-    'import/order': ['error', { groups: ['builtin', 'external', ['parent', 'sibling', 'index']] }],
+    'import/order': [
+      'error',
+      { groups: ['builtin', 'external', ['parent', 'sibling', 'index']], 'newlines-between': 'always' }
+    ],
     'import/no-extraneous-dependencies': [
       'warn',
       { devDependencies: true, optionalDependencies: true, peerDependencies: false }
-    ]
+    ],
+    'import/exports-last': 'error',
+    'import/extensions': ['error', 'always', { js: 'never' }],
+    'import/newline-after-import': ['error', { count: 1 }],
+    'import/no-amd': 'error',
+
+    'import/no-nodejs-modules': 'warn'
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
 
   rules: {
     'no-console': 'error',
+    'no-var': 'error',
     eqeqeq: ['warn', 'always', { null: 'ignore' }],
 
     'promise/no-return-wrap': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
   rules: {
     'no-console': 'error',
     'no-var': 'error',
+    'no-empty-function': 'error',
     eqeqeq: ['warn', 'always', { null: 'ignore' }],
 
     'promise/no-return-wrap': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const restrictedModules = ['gsap', 'gsap-promisify', 'bowser', 'dompurify', 'bezier-easing'];
+
 module.exports = {
   parser: 'babel-eslint',
 
@@ -27,6 +29,8 @@ module.exports = {
     'no-console': 'error',
     'no-var': 'error',
     'no-empty-function': 'error',
+    'no-restricted-modules': ['error'].concat(restrictedModules),
+    'no-restricted-imports': ['error'].concat(restrictedModules),
     eqeqeq: ['warn', 'always', { null: 'ignore' }],
 
     'promise/no-return-wrap': 'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - console calls will throw error (you will need to ignore the linter intentionally)
 - variable declaration using var will throw error
+- Not allowed empty functions
 
 ## Launch v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - variable declaration using var will throw error
 - Not allowed empty functions
 - Add more restrictions to importing modules
+- Add restricted modules to enforce use the facade
 
 ## Launch v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Launch v2.0.1
+
+- console calls will throw error (you will need to ignore the linter intentionally)
+
 ## Launch v2.0.0
 
 Remove everything related to React and keep the linting rules focus on Javascript. This config will be used for libraries and framework where React is not used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - console calls will throw error (you will need to ignore the linter intentionally)
 - variable declaration using var will throw error
 - Not allowed empty functions
+- Add more restrictions to importing modules
 
 ## Launch v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Launch v2.0.1
 
 - console calls will throw error (you will need to ignore the linter intentionally)
+- variable declaration using var will throw error
 
 ## Launch v2.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-jam3",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-jam3",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Jam3's ESLint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Changelog

- console calls will throw error (you will need to ignore the linter intentionally by line or by file)
- variable declaration using var will throw error (you will need to ignore the linter intentionally by line or by file)
- Not allowed empty functions (you will need to ignore the linter intentionally by line or by file)
- Add more restrictions to importing modules (you will need to ignore the linter intentionally by line or by file)
- Add restricted modules to enforce use the facade (you will need to ignore the linter intentionally by line or by file)